### PR TITLE
Fixing title tag in index.html to Pomolectron

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>Starter Template for Bootstrap</title>
+    <title> Pomolectron </title>
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
When Pomolectron's window is open, the app name in panel is seen as **Starter Template for Bootstrap**.
Changing the title to "Pomolectron".