### PR TITLE
Limit menubar dependency to 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "gulp": "^3.9.1"
   },
   "dependencies": {
-    "menubar": "latest"
+    "menubar": "5.2.3"
   }
 }


### PR DESCRIPTION
menubar@6 throws error: "menubar is not a function" when running the app. 